### PR TITLE
Replaced $TYPE with $NAME in voltha script

### DIFF
--- a/voltha
+++ b/voltha
@@ -2538,7 +2538,7 @@ if [ "$WITH_EFK" == "yes" ]; then
             espin - "$VERIFIED"
     fi
     EXPECT=2 # for elastic and kibana
-    if [ "$TYPE" == "minimal" ]; then
+    if [ "$NAME" == "minimal" ]; then
         EXPECT=$((EXPECT + 2)) # for fluentd on worker 2 worker nodes
     else
         EXPECT=$((EXPECT + 3)) # for fluentd on worker 3 worker nodes


### PR DESCRIPTION
"$TYPE" variable was empty in "voltha" script and for "WITH_EFK=yes" it was stuck on "  ⢎⡑ Waiting for EFK to start", because of "if" condition ($EXPECT was calculated as $EXPECT+3, but should be $EXPECT+2). In my case $EXPECT was 5, but real number of EFK containers was 4.